### PR TITLE
Crediting Monokai

### DIFF
--- a/PureBasicIDE/Preferences.pb
+++ b/PureBasicIDE/Preferences.pb
@@ -5618,7 +5618,7 @@ DataSection
   Data.l $464646 ; #COLOR_SelectionRepeat
   Data.l $000000 ; #COLOR_PlainBackground
   
-  ; base color palette created by Wimer Hazenberg (http://www.monokai.nl)
+  ; Based on the Monokai color scheme, copyright by Wimer Hazenberg (https://monokai.nl)
   Data$ "Monokai"
   Data.l $C2CFCF
   Data.l $222827

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Welcome to __PureBasic OpenSources Projects__, a central public repository to ac
     - [Forking on GitHub](#forking-on-github)
 - [Credits](#credits)
     - [Libmba](#libmba)
+    - [Monokai Theme](#monokai-theme)
     - [Silk Icon Set](#silk-icon-set)
 - [Acknowledgements](#acknowledgements)
 - [License](#license)
@@ -111,17 +112,22 @@ The MIT License
 Copyright (c) 2001-2005 Michael B. Allen <mba2000 ioplex.com>
 ```
 
+## Monokai Theme
+
+- [`PureBasicIDE/Preferences.pb`][MonokaiTheme]
+
+The PureBasic IDE uses the Monokai color scheme, created by [Wimer Hazenberg].
+
+    Monokai, copyright by Wimer Hazenberg (https://monokai.nl)
+
+The Monokai scheme is free to use provided that the above copyright notice and link to the author website are included in any work using the scheme.
+
 ## Silk Icon Set
 
 - [`PureBasicIDE/data/SilkTheme/`][SilkTheme]
 
 The __Silk Icon Theme__ included with PureBasic and SpiderBasic IDEs is based on [Mark James]'s __[Silk icon set 1.3]__, released under [CC-BY-2.5].
 Some icons were slightly modified by [Timo «Freak» Harter].
-
-## Monokai theme
-
-The PureBasic IDE uses Monokai color palette, originally created by [Wimer Hazenberg](http://www.monokai.nl).
-
 
 # Acknowledgements
 
@@ -216,8 +222,9 @@ work in the PureBasic package.
 
 <!-- project files -->
 
-[GPL License]: ./LICENSE "The GNU General Public License v3"
 [Fantaisie License]: ./LICENSE-FANTAISIE "The Fantaisie Software License"
+[GPL License]: ./LICENSE "The GNU General Public License v3"
+[MonokaiTheme]: ./PureBasicIDE/Preferences.pb#L5621 "View the source file containing the Monokai color scheme"
 
 <!-- project folders -->
 
@@ -231,5 +238,6 @@ work in the PureBasic package.
 [Gary «Kale» Willoughby]: https://www.purebasic.fr/english/memberlist.php?mode=viewprofile&u=34 "Visit Gary «Kale» Willoughby's profile on the PureBasic Forums"
 [Mark James]: https://twitter.com/markjames "Visit Mark James's profile on Twitter"
 [Timo «Freak» Harter]: https://www.purebasic.fr/english/memberlist.php?mode=viewprofile&u=25 "Visit Timo «Freak» Harter's profile on the PureBasic Forums"
+[Wimer Hazenberg]: https://www.monokai.nl/ "Visit Wimer Hazenberg's website"
 
 <!-- EOF -->


### PR DESCRIPTION
Amend the text crediting Monokai, and use the wording indicated by the original author.

Fix README file:

- Add "Monokai Theme" to TOC entries.
- Move "Monokai Theme" to alphabetical order it.
- Add link to source file using the scheme.
- Fix http:// backlink to https://
- Replace inline links with reference-style links.